### PR TITLE
WIP: extend masking of empty values to boolean fields

### DIFF
--- a/pds4_tools/reader/data_types.py
+++ b/pds4_tools/reader/data_types.py
@@ -449,10 +449,18 @@ def data_type_convert_table_ascii(data_type, data, mask_numeric_nulls=False, dec
         data = data.replace(b'false', b'0')
         data = data.split(b'@')
 
+        data = np.array(data)
+        if mask_numeric_nulls:
+            mask_array = np.zeros(len(data), dtype='bool')
+            for i, datum in enumerate(data):
+                if datum.strip() == b'':
+                    mask_array[i] = True
+            data[mask_array] = b'0'
+
         try:
-            data = np.asarray(data).astype(dtype, copy=False)
+            data = data.astype(dtype, copy=False)
         except TypeError:
-            data = np.asarray(data).astype(dtype)
+            data = data.astype(dtype)
 
     # Handle ASCII numeric types and ASCII/UTF-8 strings
     else:


### PR DESCRIPTION
Allow `Table_Delimited` ~~(and `Table_Character`?)~~  records containing empty boolean fields to be read in by PDS4 Tools, as discussed in #36.

This change applies the `mask_numeric_nulls` behaviour (`mask_array` population and `data` element dummy imputation), as already present in the wider numeric logic branch, to the boolean branch. No attempts have been made to refactor the branching for performance or DRYness, as I am not familiar enough with the codebase or potential edge cases to delve into that, but we can always tackle that at a later point if the PR is allowed to progress.

Initially tested with Python 3.6.13 / NumPy 1.19.5 to yield the desired results, i.e. records read in successfully, their empty boolean fields are of type `numpy.ma.core.MaskedConstant`, and their values are visually blanked out when viewed with `pds4_tools.view()`. 