### PR TITLE
Fix Py26 testing in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,17 +90,31 @@ jobs:
       if: (type = push) AND (tag IS present)
 
 install:
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then
+      PYPI_URL=https://files.pythonhosted.org/packages/source;
+      wget $PYPI_URL/p/pyOpenSSL/pyOpenSSL-0.13.tar.gz;
+      wget $PYPI_URL/p/pyasn1/pyasn1-0.1.9.tar.gz;
+      wget $PYPI_URL/n/ndg_httpsclient/ndg_httpsclient-0.4.0.tar.gz;
+      pip install pyOpenSSL-0.13.tar.gz;
+      pip install pyasn1-0.1.9.tar.gz;
+      pip install ndg_httpsclient-0.4.0.tar.gz;
+      sed -i '53,57s/..//' $VIRTUAL_ENV/lib/python2.6/site-packages/pip/_vendor/requests/__init__.py;
+      pip install virtualenv==14.0.5;
+    fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
+      pip install tox==3.7.0;
+    fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3.3 ]]; then
       pip install virtualenv==15.2.0;
       pip install pluggy==0.5.2;
       pip install tox==2.9.1;
     fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
-      pip install tox==3.7.0;
-    fi
   - pip install tox-travis
 
 script:
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then
+      export PYTHONUSERBASE=$VIRTUAL_ENV;
+    fi
   - tox
 
 notifications:

--- a/tox.ini
+++ b/tox.ini
@@ -19,3 +19,7 @@ deps =
     numpy1_15_0: numpy==1.15.0
     numpylatest: numpy
 commands = py.test
+
+[testenv:py26-numpy1_8_0]
+sitepackages = True
+whitelist_externals = py.test


### PR DESCRIPTION
PyPi is dropping support for clients without SNI support, https://github.com/pypa/pypi-support/issues/978. 

This means that pip running the TravisCI version of Python2.6 fails to install dependencies for CI, since it is built without SNI support. Therefore the testing fails. The workaround employed here is as follows,

  - PyOpenSSL supports adding SNI support to Python2.6
  - Pip uses requests internally
  - Requests supports using PyOpenSSL when installed  (if only it were that simple ...)
  - Latest version of pip with Python2.6 support is 9.0.3
  - Pip bundles dependencies (e.g. requests) rather than using those installed in the environment
  - pip9.0.3 patches requests to specifically comment out PyOpenSSL support (later/earlier versions do not)
  - We can wget or curl (which have SNI support) the deps needed to enable PyOpenSFTP and uncomment PyOpenSSL support in pip9.0.3
  - This is insufficient because tox creates a virtual environment, and in Travis using --site-system-packages for virtualenv does not allow it to see the top-level envs packages. Tox rejected allowing skipping of virtualenv if top-level env is already virtual in https://github.com/tox-dev/tox/issues/1181. In our config, Tox tries (and fails) to set up dependencies before we can adjust the virtualenv's environment to also enable PyOpenSFTP support
  - Therefore we adjust PYTHONUSERBASE to use the top-level environment (which is also virtual in TravisCI)
  - virtualenv still uses it's own unpatched pip (rather than a top-level env) to try to install dependencies and Tox does not expose the --no-pip flag, therefore we use an earlier version of virtualenv, which uses an earlier version of pip/requests, which does not have PyOpenSSL support commented out

We should just drop support for Py26 very soon ...