### PR TITLE
Fix Py34 testing in TravisCI due to attrs change

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,9 @@
 [tox]
-envlist = {py38,py37}-numpy{1_15_0,latest},{py27,py34,py35,py36}-numpy{1_13_0,1_8_0,latest}},{py26,py33}-numpy{1_8_0}
+envlist =
+    {py38,py37}-numpy{1_15_0,latest}
+    {py27,py35,py36}-numpy{1_13_0,1_8_0,latest}
+    {py34}-numpy{1_13_0,1_8_0,latest}-attrs_py34
+    {py26,py33}-numpy{1_8_0}
 recreate = True
 
 [testenv]
@@ -14,7 +18,8 @@ basepython =
     py38: python3.8
 deps =
     pytest
-    numpy1_8_0: numpy==1.8.0
+    attrs_py34:  attrs==20.3.0
+    numpy1_8_0:  numpy==1.8.0
     numpy1_13_0: numpy==1.13.0
     numpy1_15_0: numpy==1.15.0
     numpylatest: numpy


### PR DESCRIPTION
attrs>20.0.3 drops support for Py34. See https://github.com/python-attrs/attrs/pull/807.