### PR TITLE
Use absolute imports for tests

### DIFF
--- a/pds4_tools/tests/test_core.py
+++ b/pds4_tools/tests/test_core.py
@@ -11,18 +11,19 @@ import numpy as np
 
 from . import PDS4ToolsTestCase
 
-from ..reader.core import pds4_read
-from ..reader.data import PDS_ndarray, PDS_marray
-from ..reader.data_types import data_type_convert_dates
-from ..reader.array_objects import ArrayStructure
-from ..reader.table_objects import TableStructure, TableManifest
-from ..reader.label_objects import Label
+from pds4_tools import pds4_read
+from pds4_tools.reader.data import PDS_ndarray, PDS_marray
+from pds4_tools.reader.data_types import data_type_convert_dates
+from pds4_tools.reader.array_objects import ArrayStructure
+from pds4_tools.reader.table_objects import TableStructure, TableManifest
+from pds4_tools.reader.label_objects import Label
 
-from ..utils import compat
-from ..utils.compat import OrderedDict
-from ..utils.deprecation import PDS4ToolsDeprecationWarning, deprecated, rename_parameter, delete_parameter
+from pds4_tools.utils import compat
+from pds4_tools.utils.compat import OrderedDict
+from pds4_tools.utils.deprecation import (PDS4ToolsDeprecationWarning, deprecated,
+                                          rename_parameter, delete_parameter)
 
-from ..extern import six
+from pds4_tools.extern import six
 
 
 class TestStructureList(PDS4ToolsTestCase):


### PR DESCRIPTION
Currently we use relative imports of ``pds4_tools`` with-in tests. I think the original intent was to allow running ``pytest`` without having to ``pip install`` the code. However the relative imports mean the tests cannot be done without including the entire source code one directory up -- so if the tests are for some reason separated from the source then they do not work / cannot be run against an installed version of the code. This is affecting our conda-forge recipe.

Additionally, running ``pytest`` without ``pip install`` still works just fine when targeting the file/folder, at least on recent versions of pytest. Even if an earlier version of the package is pip installed, the targeted code will be used. However if the tests are standalone, then the pip installed version will be used. Thus pytest seems to do the right thing in all circumstances we need anyway. 