### PR TITLE
Make tkinter optional

### DIFF
--- a/pds4_tools/__init__.py
+++ b/pds4_tools/__init__.py
@@ -1,9 +1,17 @@
 from pds4_tools.__about__ import (__version__, __author__, __email__, __copyright__)
 
 from .reader import pds4_read
-from .viewer import pds4_viewer
-
 from .reader import pds4_read as read
-from .viewer import pds4_viewer as view
 
 from .utils.logging import set_loglevel
+
+try:
+    from .viewer import pds4_viewer
+    from .viewer import pds4_viewer as view
+except ImportError as e:
+
+    def _missing_optional_deps(exception, *args, **kwargs):
+        raise exception
+
+    import functools as _functools
+    pds4_viewer = view = _functools.partial(_missing_optional_deps, e)

--- a/pds4_tools/viewer/core.py
+++ b/pds4_tools/viewer/core.py
@@ -23,11 +23,9 @@ from ..extern.six.moves.tkinter import (Tk, Toplevel, PhotoImage, Menu, Scrollba
                                         Entry, Text, Button, Checkbutton, BooleanVar, StringVar, TclError)
 
 # NOTE: DO NOT IMPORT MATPLOTLIB HERE, or import any other module
-# that in-turn imports MPL or any module that imports anything that
-# should not be imported when the Viewer is not actually used. See
-# note in ``_mpl_commands`` below for explanation. This module is
-# imported by `pds4_tools.__init__``, as is any module this module
-# in-turn imports.
+# that in-turn imports MPL. See  note in ``_mpl_commands`` below
+# for explanation. This module is imported by `pds4_tools.__init__``,
+# as is any module this module in-turn imports.
 
 # Initialize the logger
 logger = logger_init()
@@ -1096,12 +1094,6 @@ def _set_icon(tk_widget, icon_name='logo'):
 # user imports anything from the package. Therefore, whenever needed, we use this function to import
 # and call the functions we otherwise would have imported at the top.
 def _mpl_commands(function_name, *args, **kwargs):
-
-    # Check if MPL is available
-    try:
-        import matplotlib as mpl
-    except ImportError:
-        return
 
     # Safe import of required MPL code
     from . import mpl as mpl_module

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     ],
 
     extras_require={
-        'viewer': ['matplotlib', 'Tkinter'],
+        'viewer': ['matplotlib'],  # tkinter
         'tests': ['pytest'],
     }
 )


### PR DESCRIPTION
tkinter is intended to be optional, but actually is required through the default import of the viewer.

A small adjustment on the pattern used in this commit could ensure no attempt to actually import `pds4_tools.viewer.core` is made at all until the user tries to call the viewer. However this breaks the docstring recognition for `pds4_viewer` by pycharm and I suspect most other  IDEs. Therefore I am sticking with the slightly different approach used here.