### PR TITLE
Fix fill values for object-dtype fields in NumPy v1.24+

### DIFF
--- a/pds4_tools/reader/data.py
+++ b/pds4_tools/reader/data.py
@@ -663,7 +663,7 @@ class PDS_marray(np.ma.MaskedArray, PDS_ndarray):
 
         if isinstance(data, np.ma.MaskedArray):
             # NumPy does not properly set fill value in record arrays for multi-dimensional fields
-            if isinstance(self.fill_value[name], np.ndarray):
+            if isinstance(self.fill_value[name], np.ndarray) and self.fill_value[name].ndim > 0:
                 self.fill_value[name][:] = data.fill_value
             else:
                 self[name].set_fill_value(data.fill_value)


### PR DESCRIPTION
When a field with-in a record array has a dtype of object, NumPy used to assign it a string containing a question mark symbol as the default fill value. Now it does the same, but the question mark is part of a 0 dimensional array. This new behavior breaks our fill_value setting code, thus we make it work again with-in this PR.