### PR TITLE
Drop support for Python 2.6 and 3.3

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.3.7', '3.4.10']
+        python-version: ['3.4.10']
     steps:
 
     - name: Checkout repo
@@ -90,54 +90,6 @@ jobs:
       run: tox
 
 
-  # Test Code for Python26
-  test-code-older-py26:
-    runs-on: ubuntu-20.04
-    container:
-      image: ubuntu:trusty
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['2.6']
-    steps:
-
-    - name: Checkout repo
-      uses: actions/checkout@v3
-
-    - name: Set up Python ${{ matrix.python-version }}
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install -y software-properties-common build-essential libssl-dev tk wget
-        wget https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/14.04/x86_64/python-2.6.tar.bz2
-        sudo tar -xjf python-2.6.tar.bz2 --directory /
-        echo "VIRTUAL_ENV=/home/travis/virtualenv/python2.6" >> $GITHUB_ENV
-
-    - name: Install dependencies
-      run: |
-        PYPI_URL=https://files.pythonhosted.org/packages/source
-        wget $PYPI_URL/p/pyOpenSSL/pyOpenSSL-0.13.tar.gz
-        wget $PYPI_URL/p/pyasn1/pyasn1-0.1.9.tar.gz
-        wget $PYPI_URL/n/ndg_httpsclient/ndg_httpsclient-0.4.0.tar.gz
-        . $VIRTUAL_ENV/bin/activate
-        pip install pyOpenSSL-0.13.tar.gz
-        pip install pyasn1-0.1.9.tar.gz
-        pip install ndg_httpsclient-0.4.0.tar.gz
-        sed -i '53,57s/..//' $VIRTUAL_ENV/lib/python2.6/site-packages/pip/_vendor/requests/__init__.py
-        pip install virtualenv==14.0.5
-        pip install tox
-
-    - name: Test Code
-      run: |
-        locale-gen en_US.UTF-8
-        export LC_ALL=en_US.UTF-8
-        export LANG=en_US.UTF-8
-        . $VIRTUAL_ENV/bin/activate
-        export PYTHONUSERBASE="$VIRTUAL_ENV"
-        version_abbr=$( echo ${{ matrix.python-version }} | sed -r 's/^([0-9])\.([0-9]).*/\1\2/' )
-        envs=$( tox -listenvs | grep "py$version_abbr-" | tr '\n' ',' )
-        tox -e $envs
-
-
   # Test Docs
   test-docs:
     runs-on: ubuntu-20.04
@@ -166,7 +118,7 @@ jobs:
   # Save Artifacts
   create-save-artifacts:
     runs-on: ubuntu-20.04
-    needs: [test-code, test-code-older-py3, test-code-older-py26, test-docs]
+    needs: [test-code, test-code-older-py3, test-code-older-py27, test-docs]
     permissions:
       contents: write
 

--- a/setup.py
+++ b/setup.py
@@ -64,10 +64,8 @@ setup(
         'Operating System :: MacOS',
 
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist =
     {py38,py37}-numpy{1_15_0,latest}
     {py27,py35,py36}-numpy{1_13_0,1_8_0,latest}
     {py34}-numpy{1_13_0,1_8_0,latest}-attrs_py34
-    {py26,py33}-numpy{1_8_0}
 recreate = True
 
 [gh-actions]
@@ -20,9 +19,7 @@ python =
 
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
-    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6
@@ -33,7 +30,6 @@ basepython =
 deps =
     pytest
     attrs_py34:  attrs==20.3.0
-    numpy1_8_0:  numpy==1.8.0
     numpy1_13_0: numpy==1.13.0
     numpy1_15_0: numpy==1.15.0
     numpy1_18_1: numpy==1.18.1
@@ -41,6 +37,3 @@ deps =
     numpylatest: numpy
 commands = py.test
 
-[testenv:py26-numpy1_8_0]
-sitepackages = True
-whitelist_externals = py.test


### PR DESCRIPTION
Python 2.6 and 3.3 are extremely old now, and testing for them is a pain. 

This commit drops official support, but does not yet yank legacy code supporting these versions.