### PR TITLE
Remove use of integer overflow when applying scaling/offset

### DIFF
--- a/pds4_tools/reader/read_arrays.py
+++ b/pds4_tools/reader/read_arrays.py
@@ -184,7 +184,7 @@ def new_array(input, no_scale=False, no_bitmask=False, masked=None, copy=True, *
                                         'value_offset': element_array.get('value_offset')}
 
     # Obtain dtype (ensuring to scale it for future application of scaling and offset if necessary)
-    dtype = pds_to_numpy_type(meta_data.data_type(), data=array, **scale_kwargs)
+    dtype = pds_to_numpy_type(meta_data.data_type(), data=array, include_unscaled=False, **scale_kwargs)
 
     # Obtain shape
     array_shape = meta_data.dimensions()

--- a/pds4_tools/reader/read_tables.py
+++ b/pds4_tools/reader/read_tables.py
@@ -682,7 +682,8 @@ def new_table(fields, no_scale=False, decode_strings=False, masked=None, copy=Tr
             data_kwargs = {'data': field}
 
         scale_kwargs = {} if no_scale else {'scaling_factor': meta_field.get('scaling_factor'),
-                                            'value_offset': meta_field.get('value_offset')}
+                                            'value_offset': meta_field.get('value_offset'),
+                                            'include_unscaled': False}
 
         # Obtain dtype (ensuring to scale it for future application of scaling and offset if necessary)
         dtype = pds_to_numpy_type(meta_field.data_type(),

--- a/pds4_tools/tests/test_core.py
+++ b/pds4_tools/tests/test_core.py
@@ -1250,12 +1250,10 @@ class TestMaskedData(PDS4ToolsTestCase):
     def test_array_scaling_with_special_constants(self):
 
         # Test that Special_Constants are ignored during scaling/offset for arrays (integers)
-        # Note: It may appear that the dtype here should be uint32. See Notes section of
-        # `pds4_tools.reader.data_types.get_scaled_numpy_type` for details as to why it is not.
         array_unsigned_msb4 = self.structures[3]
 
         unsigned_msb4 = [251746175, 3994967214, 3994967214, 1217070]
-        _check_array_equal(array_unsigned_msb4.data, unsigned_msb4, 'int64')
+        _check_array_equal(array_unsigned_msb4.data, unsigned_msb4, 'uint32')
 
         # Test that Special_Constants are ignored during scaling/offset for arrays (reals)
         array_lsb_double = self.structures[4]


### PR DESCRIPTION
In `pds4_tools.reader.data_types.adjust_array_data_type`, there can be an integer overflow on scaling / offset application when the scaled data is smaller than the initial data, through the fact that the array is converted to a new data type prior to the scaling (at which point it doesn't yet fit into the new data type). As far as I can see, since the only use of this function is in `pds4_tools.reader.data_types.apply_scaling_and_value_offset`, which then applies an operation that cancels out the overflow, thus it didn't actually cause invalid values (at least in the test suite) but I am not absolutely sure if that's generally true.

In this fix, while also fixing the bug in the prior code, I go beyond the protection the prior code was supposed to have, modifying `pds4_tools.reader.data_types.get_scaled_numpy_type` to more explicitly include the `include_unscaled` argument that will not cast down integers if the initial data does not fit. 

Additionally, I improve memory efficiency at the cost of CPU / run time by casting integers down after the scaling / offset is applied. 