### PR TITLE
Add support for NumPy v2.0

### DIFF
--- a/pds4_tools/reader/data.py
+++ b/pds4_tools/reader/data.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from .data_types import pds_to_numpy_name
 
-from ..utils.compat import OrderedDict
+from ..utils.compat import OrderedDict, np_issubclass
 from ..extern import six
 
 
@@ -537,7 +537,7 @@ class PDS_marray(np.ma.MaskedArray, PDS_ndarray):
             obj = super(PDS_marray, self).view(dtype=dtype, type=type, fill_value=fill_value)
 
             # Fix bug in NumPy < v1.10, which resets fill value on ``view`` if mask is not nomask
-            if ((dtype is None) or ((type is None) and np.issubclass_(dtype, np.ma.MaskedArray))) and \
+            if ((dtype is None) or ((type is None) and np_issubclass(dtype, np.ma.MaskedArray))) and \
                 (fill_value is None):
 
                 obj._fill_value = self._fill_value

--- a/pds4_tools/utils/compat.py
+++ b/pds4_tools/utils/compat.py
@@ -6,6 +6,8 @@ from __future__ import unicode_literals
 import inspect
 from xml.etree import ElementTree as ET
 
+import numpy as np
+
 from ..extern import six
 
 # OrderedDict compat (Python 2.7+ and 3.1+)
@@ -25,6 +27,17 @@ ET_Element = ET.Element if isinstance(ET.Element, six.class_types) else ET._Elem
 ET_Tree_iter = ET.ElementTree.iter if hasattr(ET.ElementTree, 'iter') else ET.ElementTree.getiterator
 ET_Element_iter = ET_Element.iter if hasattr(ET_Element, 'iter') else ET_Element.getiterator
 ET_ParseError = ET.ParseError if hasattr(ET, 'ParseError') else None
+
+# NumPy compat (NumPy 2.0+)
+try:
+    np_unicode = np.unicode_
+except AttributeError:
+    np_unicode = np.str_
+
+try:
+    np_issubclass = np.issubclass_
+except AttributeError:
+    np_issubclass = issubclass
 
 
 # signature.bind(...).arguments compat (Python 3.3+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 envlist =
-    {py310}-numpy{1_21_0,latest}
-    {py39}-numpy{1_19_3,latest}
-    {py38,py37}-numpy{1_15_0,latest}
-    {py27,py35,py36}-numpy{1_13_0,1_8_0,latest}
-    {py34}-numpy{1_13_0,1_8_0,latest}-attrs_py34
+    {py310}-numpy{1_21_0,1_26_4,latest}
+    {py39}-numpy{1_19_3,1_26_4,latest}
+    {py37,py38}-numpy{1_15_0,latest}
+    {py35,py36}-numpy{1_13_0,latest}
+    {py34}-numpy{1_8_0,1_13_0,latest}-attrs_py34
+    {py27}-numpy{1_8_0,1_13_0,latest}
 recreate = True
 
 [gh-actions]
@@ -29,10 +30,12 @@ basepython =
 deps =
     pytest
     attrs_py34:  attrs==20.3.0
+    numpy1_8_0:  numpy==1.8.0
     numpy1_13_0: numpy==1.13.0
     numpy1_15_0: numpy==1.15.0
     numpy1_19_3: numpy==1.19.3
     numpy1_21_0: numpy==1.21.0
+    numpy1_26_4: numpy==1.26.4
     numpylatest: numpy
 commands = py.test
 


### PR DESCRIPTION
NumPy 2.0 has been released, with certain non-backwards compatible changes. These include at least the following changes that affect PDS4 Python Tools,

1) NEP 50, which makes type casting more explicit. For example, `np.asarray([-5, -10], dtype='int8') + 128` no longer works because 128 is out of bounds for dtype `int8`.
2) Type casting string arrays directly into bool now seems to make anything other than an empty value `True`
3) `np.unicode_` has been replaced by `np.str_`, and support for Python 2 dropped
4) `np.issubclass_` has been replaced by built-in `issubclass`

Closes #93 and #94.