### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -43,9 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.4.10', '3.5.10']
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+        python-version: ['3.5.10']
     steps:
 
     - name: Checkout repo

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist =
     {py39}-numpy{1_19_3,1_26_4,latest}
     {py37,py38}-numpy{1_15_0,latest}
     {py35,py36}-numpy{1_13_0,latest}
-    {py34}-numpy{1_8_0,1_13_0,latest}-attrs_py34
     {py27}-numpy{1_8_0,1_13_0,latest}
 recreate = True
 
@@ -24,7 +23,6 @@ python =
 [testenv]
 basepython =
     py27: python2.7
-    py34: python3.4
     py35: python3.5
     py36: python3.6
     py37: python3.7
@@ -33,7 +31,6 @@ basepython =
     py310: python3.10
 deps =
     pytest
-    attrs_py34:  attrs==20.3.0
     numpy1_8_0:  numpy==1.8.0
     numpy1_13_0: numpy==1.13.0
     numpy1_15_0: numpy==1.15.0


### PR DESCRIPTION
Python 3.4 is very old now, and testing for it is a pain because of the challenge of getting a properly working build/test evironment.

This commit drops official support, but does not yet yank legacy code supporting these versions.
