### PR TITLE
Use more recent runner images for GitHub Actions builds

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -11,13 +11,11 @@ jobs:
 
   # Test Code for recent Python releases
   test-code:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
@@ -27,10 +25,10 @@ jobs:
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -45,39 +43,37 @@ jobs:
 
   # Test Code for older Python3 releases
   test-code-older-py3:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: python:${{ matrix.python-version }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.5.10']
+        python-version:
+          - '3.5.10'
+          - '3.6.15'
+          - '3.7.17'
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install dependencies
       shell: bash
       run: |
-        if [[ ${{ matrix.python-version }} == 3.3* ]]; then
-          python -m pip install virtualenv==15.2.0
-          python -m pip install pluggy==0.5.2
-          python -m pip install tox==2.9.1
-        fi
         python -m pip install tox
 
     - name: Test Code
       shell: bash
       run: |
         version_abbr=$( echo ${{ matrix.python-version }} | sed -r 's/^([0-9])\.([0-9]).*/\1\2/' )
-        envs=$( tox -listenvs | grep "py$version_abbr-" | tr '\n' ',' )
+        envs=$( tox --listenvs | grep "py$version_abbr-" | tr '\n' ',' )
         tox -e $envs
 
 
   # Test Code for Python27
   test-code-older-py27:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: python:${{ matrix.python-version }}
     strategy:
@@ -88,7 +84,7 @@ jobs:
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |
@@ -101,16 +97,16 @@ jobs:
 
   # Test Docs
   test-docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
 
@@ -126,7 +122,7 @@ jobs:
 
   # Save Artifacts
   create-save-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [test-code, test-code-older-py3, test-code-older-py27, test-docs]
     permissions:
       contents: write
@@ -134,10 +130,10 @@ jobs:
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
 
@@ -190,14 +186,14 @@ jobs:
 
   # Deploy to GitHub Releases
   deploy-github-releases:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [create-save-artifacts]
     if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Deploy to GitHub Releases
       shell: bash
@@ -220,17 +216,17 @@ jobs:
 
   # Deploy to PyPi
   deploy-pypi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: [create-save-artifacts]
     if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     {py312,py313}-numpy{1_26_4,latest}
     {py311}-numpy{1_23_0,1_26_4,latest}
-    {py310}-numpy{1_21_0,1_26_4,latest}
+    {py310}-numpy{1_21_1,1_26_4,latest}
     {py39}-numpy{1_19_3,1_26_4,latest}
     {py38}-numpy{1_17_3,latest}
     {py37}-numpy{1_15_0,latest}
@@ -38,7 +38,7 @@ deps =
     numpy1_15_0: numpy==1.15.0
     numpy1_17_3: numpy==1.17.3
     numpy1_19_3: numpy==1.19.3
-    numpy1_21_0: numpy==1.21.0
+    numpy1_21_1: numpy==1.21.1
     numpy1_23_0: numpy==1.23.0
     numpy1_26_4: numpy==1.26.4
     numpylatest: numpy


### PR DESCRIPTION
Support for Ubuntu 20.04 runners is about to be dropped by GitHub Actions. We are also using an older version of some actions, which use those older runners.