### PR TITLE
Fix `numpy_to_pds_type` library function

### DIFF
--- a/pds4_tools/tests/compat.py
+++ b/pds4_tools/tests/compat.py
@@ -6,6 +6,16 @@ from __future__ import unicode_literals
 import sys
 import xml.etree.ElementTree as ET
 
+import numpy as np
+
+
 PY26 = sys.version_info[0:2] == (2, 6)
 
+# ElementTree compat (Python 2.7+ and 3.3+)
 ET_Element = ET._Element if PY26 else ET.Element
+
+# NumPy compat (NumPy 2.0+)
+try:
+    np_unicode = np.unicode_
+except AttributeError:
+    np_unicode = np.str_


### PR DESCRIPTION
Fixes several issues with the `pds4_tools.reader.data_types.numpy_to_pds_type` function,

* Compatibility with NumPy >= 2.0
* Compatibility with NumPy >= 1.23 when for ASCII numerics
* Fix incorrect return value for signed ASCII integers
* Distinguish between dates and datetimes

Adds testing for this function into the test suite.

Closes #127.