### PR TITLE
Replaced deprecated tkinter trace methods with new versions

### DIFF
--- a/pds4_tools/utils/compat.py
+++ b/pds4_tools/utils/compat.py
@@ -22,6 +22,22 @@ try:
 except ImportError:
     from ..extern import argparse
 
+
+# Tkinter compat (Python 3.6+)
+def tk_trace_add(variable, mode, callback):
+    try:
+        return variable.trace_add(mode, callback)
+    except AttributeError:
+        return variable.trace(mode[0], callback)
+
+
+def tk_trace_remove(variable, mode, callback_id):
+    try:
+        return variable.trace_remove(mode, callback_id)
+    except AttributeError:
+        return variable.trace_vdelete(mode[0], callback_id)
+
+
 # ElementTree compat (Python 2.7+ and 3.3+)
 ET_Element = ET.Element if isinstance(ET.Element, six.class_types) else ET._Element
 ET_Tree_iter = ET.ElementTree.iter if hasattr(ET.ElementTree, 'iter') else ET.ElementTree.getiterator

--- a/pds4_tools/viewer/image_view.py
+++ b/pds4_tools/viewer/image_view.py
@@ -111,7 +111,7 @@ class ImageViewWindow(DataViewWindow):
             var = option['type']
             self._menu_options[option['name']] = var
 
-            self._add_trace(var, 'w', option['trace'], option['default'])
+            self._add_trace(var, 'write', option['trace'], option['default'])
 
     @property
     def settings(self):
@@ -2461,7 +2461,7 @@ class DataCubeWindow(Window):
 
         self._selected_axis = IntVar()
         self._selected_axis.set(self._structure_window.settings['selected_axis'])
-        self._add_trace(self._selected_axis, 'w',
+        self._add_trace(self._selected_axis, 'write',
                         lambda *args: self._structure_window.select_slice(axis=self._selected_axis.get()))
 
         self._sliders = []
@@ -2514,7 +2514,7 @@ class DataCubeWindow(Window):
 
             slider_var = IntVar()
             slider_var.set(axis_slice)
-            self._add_trace(slider_var, 'w', lambda *args: self._slider_moved(slider_index, axis_sequence))
+            self._add_trace(slider_var, 'write', lambda *args: self._slider_moved(slider_index, axis_sequence))
 
             slider_row_box = Frame(self._sliders_box, bg=self.get_bg('gray'))
             slider_row_box.pack(pady=(20, 10), expand=1, fill='x')
@@ -2593,7 +2593,7 @@ class ScaleParametersWindow(Window):
             var = option['type']
             self._menu_options[option['name']] = var
 
-            self._add_trace(var, 'w', option['trace'], option['default'])
+            self._add_trace(var, 'write', option['trace'], option['default'])
 
         # Add the menu
         self._add_menus()

--- a/pds4_tools/viewer/label_view.py
+++ b/pds4_tools/viewer/label_view.py
@@ -38,12 +38,12 @@ class LabelWindow(SearchableTextWindowMixIn, Window):
         # Stores what display type is currently selected
         display_type = StringVar()
         self._menu_options['display_type'] = display_type
-        self._add_trace(display_type, 'w', self._update_label, default=initial_display)
+        self._add_trace(display_type, 'write', self._update_label, default=initial_display)
 
         # Stores whether label is being pretty printed or shown as in the file
         pretty_print = BooleanVar()
         self._menu_options['pretty_print'] = pretty_print
-        self._add_trace(pretty_print, 'w', self._update_label, default=True)
+        self._add_trace(pretty_print, 'write', self._update_label, default=True)
 
         # Draw the main window content
         self._set_heading('Label')

--- a/pds4_tools/viewer/plot_view.py
+++ b/pds4_tools/viewer/plot_view.py
@@ -96,7 +96,7 @@ class PlotViewWindow(DataViewWindow):
             var = option['type']
             self._menu_options[option['name']] = var
 
-            self._add_trace(var, 'w', option['trace'], option['default'])
+            self._add_trace(var, 'write', option['trace'], option['default'])
 
     @property
     def settings(self):
@@ -2469,7 +2469,8 @@ class PlotOptionsWindow(Window):
 
         current_axis_limits = self._structure_window.menu_option('axis_limits')
         axis_limits = self._axes_options['axis_limits'] = StringVar()
-        self._add_trace(axis_limits, 'w', self._update_limits_setting, default=current_axis_limits.capitalize())
+        self._add_trace(axis_limits, 'write',
+                        self._update_limits_setting, default=current_axis_limits.capitalize())
 
         menu = OptionMenu(option_menus_box, axis_limits, *('Intelligent', 'Tight', 'Auto', 'Manual'))
         menu.config(width=15, **option_menu_params)
@@ -2480,7 +2481,8 @@ class PlotOptionsWindow(Window):
         manual_limits_box.pack(side='top', anchor='nw', pady=10)
 
         manual_limits = BooleanVar()
-        self._add_trace(manual_limits, 'w', self._update_limits_setting, default=(current_axis_limits == 'manual'))
+        self._add_trace(manual_limits, 'write',
+                        self._update_limits_setting, default=(current_axis_limits == 'manual'))
 
         b = Checkbutton(manual_limits_box, text='Manual Limits', variable=axis_limits,
                         onvalue='Manual', offvalue='Intelligent', **text_params)

--- a/pds4_tools/viewer/summary_view.py
+++ b/pds4_tools/viewer/summary_view.py
@@ -546,13 +546,16 @@ class StructureListWindow(Window):
 
         # Initialize menu options
         self._menu_options['quiet'] = BooleanVar()
-        self._add_trace(self._menu_options['quiet'], 'w', self._update_quiet, default=quiet)
+        self._add_trace(self._menu_options['quiet'], 'write',
+                        self._update_quiet, default=quiet)
 
         self._menu_options['lazy_load'] = BooleanVar()
-        self._add_trace(self._menu_options['lazy_load'], 'w', self._update_lazy_load, default=lazy_load)
+        self._add_trace(self._menu_options['lazy_load'], 'write',
+                        self._update_lazy_load, default=lazy_load)
 
         self._menu_options['show_headers'] = BooleanVar()
-        self._add_trace(self._menu_options['show_headers'], 'w', self._update_show_headers, default=show_headers)
+        self._add_trace(self._menu_options['show_headers'], 'write',
+                        self._update_show_headers, default=show_headers)
 
         # Add a File menu
         file_menu = self._add_menu('File', in_menu='main')

--- a/pds4_tools/viewer/table_view.py
+++ b/pds4_tools/viewer/table_view.py
@@ -63,7 +63,7 @@ class TabularViewWindow(DataViewWindow):
             var = option['type']
             self._menu_options[option['name']] = var
 
-            self._add_trace(var, 'w', option['trace'], option['default'])
+            self._add_trace(var, 'write', option['trace'], option['default'])
 
         # These variables are used to store widgets, and info about them, used for displaying tabular data
         self._data_boxes = []


### PR DESCRIPTION
Fixes https://github.com/Small-Bodies-Node/pds4_tools/issues/136.

I've updated the tkinter code to use the new trace methods that were introduced in Python 3.6, which replace the deprecated versions that were recently removed.